### PR TITLE
Migrate to fx140 (or Zotero 8)

### DIFF
--- a/lib/logging/00-directory-manager.js
+++ b/lib/logging/00-directory-manager.js
@@ -1,7 +1,6 @@
-Components.utils.import("resource://gre/modules/FileUtils.jsm");
-
 var DirectoryManager = class {
     constructor() {
+        const { FileUtils } = ChromeUtils.importESModule('resource://gre/modules/FileUtils.sys.mjs');
         this.dataDirectory = new FileUtils.File(Zotero.DataDirectory.dir);
         this.dataDirectory.append('logs');
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZotMoov",
-  "version": "1.2.22",
+  "version": "1.2.21",
   "description": "Mooves attachments and links them",
   "author": "Wiley Yu & Mr. Hoorn",
   "applications": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZotMoov",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Mooves attachments and links them",
   "author": "Wiley Yu & Mr. Hoorn",
   "applications": {
@@ -9,7 +9,7 @@
       "id": "zotmoov@wileyy.com",
       "update_url": "https://raw.githubusercontent.com/wileyyugioh/zotmoov/master/updates.json",
       "strict_min_version": "6.999",
-      "strict_max_version": "7.1.*"
+      "strict_max_version": "8.0.*"
     }
   }
 }

--- a/src/00-zotmoov-wildcard.js
+++ b/src/00-zotmoov-wildcard.js
@@ -1,5 +1,3 @@
-Components.utils.importGlobalProperties(['PathUtils']);
-
 var ZotMoovWildcard = class {
     // Some of this code is modfied from https://github.com/jlegewie/zotfile/blob/e0c1fa1d3d92716bdec56fddd6e07f563a535d95/chrome/content/zotfile/wildcards.js
 

--- a/src/02-zotmoov.js
+++ b/src/02-zotmoov.js
@@ -1,5 +1,3 @@
-Components.utils.importGlobalProperties(['PathUtils', 'IOUtils']);
-
 var ZotMoov = class {
     constructor(id, version, rootURI, wildcard, sanitizer, zotmoov_debugger) {
         this.id = id;


### PR DESCRIPTION
For #108
See https://www.zotero.org/support/dev/zotero_8_for_developers
Changes:
- How `FileUtils` is imported
  - It's working, but I'm not sure it's a recommended way. 
- Migrate to async from Zotero.Promise
  - This is done via [script provided by upstream](https://github.com/zotero/zotero/tree/main/scripts/migrate-fx140)
- Remove `Components.utils.importGlobalProperties`

For those who need working xpi use https://www.dropbox.com/scl/fi/hk7g8x4hmo83s3ikhsbyw/zotmoov-1.2.22-pr109-fx.xpi?rlkey=rehs7q6688bpc4pcfelhf67kx&st=q0uyy7on&dl=0 at your own risk

 
  